### PR TITLE
Added TypeError in catch to overcome the TypeError when visibility would return null in adapter

### DIFF
--- a/src/Flysystem/StreamCommand/StreamStatCommand.php
+++ b/src/Flysystem/StreamCommand/StreamStatCommand.php
@@ -16,6 +16,7 @@ use League\Flysystem\Visibility;
 use M2MTech\FlysystemStreamWrapper\Flysystem\Exception\StatFailedException;
 use M2MTech\FlysystemStreamWrapper\Flysystem\FileData;
 use M2MTech\FlysystemStreamWrapper\FlysystemStreamWrapper;
+use TypeError;
 
 final class StreamStatCommand
 {
@@ -114,7 +115,7 @@ final class StreamStatCommand
 
         try {
             $visibility = $current->filesystem->visibility($current->file);
-        } catch (UnableToRetrieveMetadata $e) {
+        } catch (UnableToRetrieveMetadata | TypeError $e) {
             if (!$current->ignoreVisibilityErrors()) {
                 throw $e;
             }


### PR DESCRIPTION
Added only an extra TypeError for now, although that would still mean that any other exception thrown would still end up breaking the code