### PR TITLE
fix: Avoid exception when handling lastModified of directories in StreamStatCommand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ FlysystemStreamWrapper::register('fly', $filesystem, [
 ]);
 ```
 
+### Problems with Directories (`file_exists` / `is_dir`)
+
+To provide fully transparent behaviour for directories enable the emulation of
+last modified timestamp, and ignore visibility errors, e.g.:
+
+```php
+FlysystemStreamWrapper::register('fly', $filesystem, [
+    FlysystemStreamWrapper::IGNORE_VISIBILITY_ERRORS => true,
+    FlysystemStreamWrapper::EMULATE_DIRECTORY_LAST_MODIFIED => true,
+]);
+```
+
 ### Problems with `is_readable` / `is_writable`
 
 A couple of filesystem functions use `uid` and `gid` of the user running php. Unfortunately there is no straight forward cross-plattform usable method available to derive those values. The wrapper tries to *guess* them. But depending on your system settings it might fail.

--- a/src/Flysystem/FileData.php
+++ b/src/Flysystem/FileData.php
@@ -74,4 +74,9 @@ final class FileData
     {
         return (bool) $this->config[FlysystemStreamWrapper::IGNORE_VISIBILITY_ERRORS];
     }
+
+    public function emulateDirectoryLastModified(): bool
+    {
+        return (bool) $this->config[FlysystemStreamWrapper::EMULATE_DIRECTORY_LAST_MODIFIED];
+    }
 }

--- a/src/FlysystemStreamWrapper.php
+++ b/src/FlysystemStreamWrapper.php
@@ -24,6 +24,8 @@ final class FlysystemStreamWrapper
 
     public const IGNORE_VISIBILITY_ERRORS = 'ignore_visibility_errors';
 
+    public const EMULATE_DIRECTORY_LAST_MODIFIED = 'emulate_directory_last_modified';
+
     public const UID = 'uid';
     public const GID = 'gid';
 
@@ -38,6 +40,7 @@ final class FlysystemStreamWrapper
         self::LOCK_TTL => 300,
 
         self::IGNORE_VISIBILITY_ERRORS => false,
+        self::EMULATE_DIRECTORY_LAST_MODIFIED => false,
 
         self::UID => null,
         self::GID => null,


### PR DESCRIPTION
Came across errors when using `file_exists()` aka "StreamStatCommand" on directories.

Then call `$lastModified = $current->filesystem->lastModified($current->file);` throws `UnableToRetrieveMetadata` exceptions but contrary to the visibility there was no handling of this case.

I'm not entirely sure if a a thrown exception is desirable in some cases, but for now I went for no exception, but `false` as default value with the option to "emulate" a timestamp based on the container files of a folder. For that the new flag `FlysystemStreamWrapper::EMULATE_DIRECTORY_LAST_MODIFIED` was introduced.

* ✅ README.md has been updated
* ⚠️ Tests haven't been added yet.