### PR TITLE
fix: use collectErrorMessage on StreamWrapper warning

### DIFF
--- a/src/Flysystem/StreamWrapper.php
+++ b/src/Flysystem/StreamWrapper.php
@@ -10,6 +10,7 @@
 namespace M2MTech\FlysystemStreamWrapper\Flysystem;
 
 use League\Flysystem\FilesystemException;
+use M2MTech\FlysystemStreamWrapper\Flysystem\StreamCommand\ExceptionHandler;
 use M2MTech\FlysystemStreamWrapper\Flysystem\StreamCommand\StreamWriteCommand;
 
 /**
@@ -17,6 +18,8 @@ use M2MTech\FlysystemStreamWrapper\Flysystem\StreamCommand\StreamWriteCommand;
  */
 final class StreamWrapper
 {
+    use ExceptionHandler;
+
     /** @var FileData */
     private $current;
 
@@ -64,7 +67,7 @@ final class StreamWrapper
                 $this->current->filesystem->writeStream($this->current->file, $this->current->handle);
             } catch (FilesystemException $e) {
                 trigger_error(
-                    'stream_close('.$this->current->path.') Unable to sync file : '.$e->getMessage(),
+                    'stream_close('.$this->current->path.') Unable to sync file : '.self::collectErrorMessage($e),
                     E_USER_WARNING
                 );
             }
@@ -95,7 +98,7 @@ final class StreamWrapper
                 $this->current->filesystem->writeStream($this->current->file, $this->current->handle);
             } catch (FilesystemException $e) {
                 trigger_error(
-                    'stream_flush('.$this->current->path.') Unable to sync file : '.$e->getMessage(),
+                    'stream_flush('.$this->current->path.') Unable to sync file : '.self::collectErrorMessage($e),
                     E_USER_WARNING
                 );
                 $success = false;


### PR DESCRIPTION
We are losing the previous exception messages on warnings triggered by `StreamWrapper`, which is very inconvenient for debugging. 
I am therefore using the `ExceptionHandler::collectErrorMessage()` method to have the same behavior as the `StreamCommand`.