### PR TITLE
fix: php deprecation

### DIFF
--- a/src/Flysystem/StreamWrapper.php
+++ b/src/Flysystem/StreamWrapper.php
@@ -23,7 +23,7 @@ final class StreamWrapper
     /** @var FileData */
     private $current;
 
-    public function __construct(FileData $current = null)
+    public function __construct(?FileData $current = null)
     {
         $this->current = $current ?? new FileData();
     }


### PR DESCRIPTION
I'm currently getting this deprecation on symfony 7.2 and php 8.4:

```
Deprecated: M2MTech\\FlysystemStreamWrapper\\Flysystem\\StreamWrapper::__construct(): Implicitly marking parameter $current as nullable is deprecated, the explicit nullable type must be used instead
```