### PR TITLE
PHP 8.4. Fix implicit nullable parameter

### DIFF
--- a/src/Flysystem/StreamWrapper.php
+++ b/src/Flysystem/StreamWrapper.php
@@ -23,7 +23,7 @@ final class StreamWrapper
     /** @var FileData */
     private $current;
 
-    public function __construct(FileData $current = null)
+    public function __construct(?FileData $current = null)
     {
         $this->current = $current ?? new FileData();
     }


### PR DESCRIPTION
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated