### PR TITLE
Check resource before closing stream handle

### DIFF
--- a/src/Flysystem/StreamWrapper.php
+++ b/src/Flysystem/StreamWrapper.php
@@ -71,6 +71,10 @@ final class StreamWrapper
                     E_USER_WARNING
                 );
             }
+
+            if (!is_resource($this->current->handle)) {
+                return;
+            }
         }
 
         fclose($this->current->handle);

--- a/tests/Issues/AdapterClosesStreamTest.php
+++ b/tests/Issues/AdapterClosesStreamTest.php
@@ -9,7 +9,10 @@
 
 namespace M2MTech\FlysystemStreamWrapper\Tests\Issues;
 
+use League\Flysystem\FilesystemOperator;
+use M2MTech\FlysystemStreamWrapper\Flysystem\FileData;
 use M2MTech\FlysystemStreamWrapper\Flysystem\StreamWrapper;
+use M2MTech\FlysystemStreamWrapper\FlysystemStreamWrapper;
 use M2MTech\FlysystemStreamWrapper\Tests\Assert;
 use M2MTech\FlysystemStreamWrapper\Tests\StreamCommand\AbstractStreamCommandTestCase;
 
@@ -30,6 +33,34 @@ class AdapterClosesStreamTest extends AbstractStreamCommandTestCase
         // adapter closes stream itself
         fclose($current->handle);
         $this->assertIsClosedResource($current->handle);
+
+        $wrapper->stream_close();
+        $this->assertIsClosedResource($current->handle);
+    }
+
+    public function testStreamCloseWithLocalCopy(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        FlysystemStreamWrapper::register(self::TEST_PROTOCOL, $filesystem);
+
+        $current = new FileData();
+        $current->setPath(self::TEST_PATH);
+
+        $current->handle = fopen('php://temp', 'wb');
+        $current->workOnLocalCopy = true;
+
+        $wrapper = new StreamWrapper($current);
+
+        if (!is_resource($current->handle)) {
+            $this->fail();
+        }
+
+        $filesystem->expects($this->once())
+            ->method('writeStream')
+            ->willReturnCallback(static function (string $file, $handle) {
+                // adapter closes the stream itself after writing it to file
+                fclose($handle);
+            });
 
         $wrapper->stream_close();
         $this->assertIsClosedResource($current->handle);


### PR DESCRIPTION
After the specific Flysystem Adapter wrote the stream, it might have closed it.  
So we double-check before trying to close it again.  
  
This happens for `league/flysystem-aws-s3-v3` -> `aws/aws-sdk-php` -> `guzzlehttp/psr7` and stream is wrapped in `GuzzleHttp\Psr7\Stream` that on destruct closes it.  
Maybe they shouldn't close it, but we're not in control of it. So double-checking sounds reasonable.  
